### PR TITLE
nat_get_contact_sip_uri was changed to ast_sip_get_contact_sip_uri

### DIFF
--- a/res/res_pjsip_nat.c
+++ b/res/res_pjsip_nat.c
@@ -382,7 +382,7 @@ static pj_status_t process_nat(pjsip_tx_data *tdata)
 		}
 	} else {
 		/* set contact port to the bound to port */
-		if (uri || (uri = nat_get_contact_sip_uri(tdata))) {
+		if (uri || (uri = ast_sip_get_contact_sip_uri(tdata))) {
 			if (pj_sockaddr_get_port(&transport_state->host)) {
 				uri->port = pj_sockaddr_get_port(&transport_state->host);
 			}


### PR DESCRIPTION
From https://github.com/ccxtechnologies/builder/issues/3822#issuecomment-1856621135

When merging 18.20.0 it looks like one nat_get_contact_sip_uri was changed to ast_sip_get_contact_sip_uri, but not the other

https://github.com/ccxtechnologies/asterisk/commit/36fc96f4c9c360d4bf3f77f767d283ba8eb9f847#diff-631b54ff5c5e9b096c4365976bc993d69265fab4410077fdfa9dade75c6fa892
![Screenshot from 2023-12-14 16-12-24](https://github.com/ccxtechnologies/builder/assets/46680674/22553b1e-5856-452a-87e9-35473b3d5a87)

This is because 18.20.0 (https://github.com/asterisk/asterisk/blob/18.20.0/res/res_pjsip_nat.c) does not have that code, it was added by us here:
https://github.com/ccxtechnologies/asterisk/commit/86afe10afe5f92427fffe0a39fb9d0ad650a290a

I think we can just update the call to nat_get_contact_sip_uri with ast_sip_get_contact_sip_uri

