### PR TITLE
Fix iax reachable

### DIFF
--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -11272,7 +11272,7 @@ static int socket_process_helper(struct iax2_thread *thread)
 				if (iaxs[fr->callno]->peerpoke) {
 					RAII_VAR(struct ast_json *, blob, NULL, ast_json_unref);
 					peer = iaxs[fr->callno]->peerpoke;
-					if ((peer->lastms < 0)  || (peer->historicms > peer->maxms)) {
+					if ((peer->lastms <= 0)  || (peer->historicms > peer->maxms)) {
 						if (iaxs[fr->callno]->pingtime <= peer->maxms) {
 							ast_log(LOG_NOTICE, "Peer '%s' is now REACHABLE! Time: %u\n", peer->name, iaxs[fr->callno]->pingtime);
 							ast_endpoint_set_state(peer->endpoint, AST_ENDPOINT_ONLINE);
@@ -12984,7 +12984,6 @@ static struct iax2_peer *build_peer(const char *name, struct ast_variable *v, st
 		}
 		unlink_peer(peer);
 	} else if ((peer = ao2_alloc(sizeof(*peer), peer_destructor))) {
-		peer->lastms = -1;
 		peer->expire = -1;
 		peer->pokeexpire = -1;
 		peer->sockfd = defaultsockfd;

--- a/channels/chan_iax2.c
+++ b/channels/chan_iax2.c
@@ -12984,6 +12984,7 @@ static struct iax2_peer *build_peer(const char *name, struct ast_variable *v, st
 		}
 		unlink_peer(peer);
 	} else if ((peer = ao2_alloc(sizeof(*peer), peer_destructor))) {
+		peer->lastms = -1;
 		peer->expire = -1;
 		peer->pokeexpire = -1;
 		peer->sockfd = defaultsockfd;


### PR DESCRIPTION
Issue: https://github.com/ccxtechnologies/builder/issues/5579#issuecomment-3740739630

Problem: iax trunk reachable indicator not turning true even when the trunk is reachable

Root cause: our asterisk module sets reachable for trunks based on ami peer status event messages, informing us that the trunk is reachable. In the asterisk backend, the reachable message is only pinged if the previous state was unreachable, as in `lastms` is -1, but to begin with, `lastms` is intialized to 0, which is an unknown state, so on creation, the trunk indicator does not change because the initial state is unknown, not unreachable, and so asterisk never pings the reachable event despite it being reachable. 

Fix: Allow both unreachable and unknown states to ping reachable in asterisk. 